### PR TITLE
Improve the Find your accounts page with real-time email validation and safer url

### DIFF
--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -41,10 +41,40 @@
                     {{ csrf_input }}
                     <div class="input-box moving-label horizontal">
                         <div class="inline-block relative">
-                            <input type="text" autofocus id="emails" name="emails" required />
+                            <input type="text" autofocus id="emails" name="emails" required onKeyUp="checkInput()"/>
                             <label for="emails">{{ _('Email addresses') }}</label>
                         </div>
-                        <button type="submit">{{ _('Find accounts') }}</button>
+                        <button type="submit" id="submit">{{ _('Find accounts') }}</button>
+                        <script>
+                            var inputEmails = document.getElementById('emails');
+                            var findAccountButton = document.getElementById('submit');
+                            var originalBackgroundColor = findAccountButton.style.backgroundColor;
+                            function validEmails(val) {
+                                var emails = val.replace(/\s/g,'').split(",");
+                                var valid = true;
+                                var regex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+                                for (var i = 0; i < emails.length; i++) {
+                                    if( emails[i] == "" || ! regex.test(emails[i])){
+                                        valid = false;
+                                    }
+                                }
+                                return valid
+                            }
+                            function checkInput() {
+                                var emailList = inputEmails.value;
+                                if (validEmails(emailList)){
+                                    findAccountButton.disabled = false;
+                                    findAccountButton.style.backgroundColor = originalBackgroundColor;
+                                    findAccountButton.style.cursor = "pointer";
+                                    findAccountButton.style["pointer-events"] = "auto";
+                                } else {
+                                    findAccountButton.disabled = true;
+                                    findAccountButton.style.backgroundColor = 'grey';
+                                    findAccountButton.style.cursor = "not-allowed";
+                                    findAccountButton.style["pointer-events"] = "none";
+                                }
+                            }
+                        </script>
                     </div>
                     <div><i>{{ form.emails.help_text }}</i></div>
                 </form>
@@ -54,6 +84,7 @@
                     <div class="alert alert-error">{{ error }}</div>
                     {% endfor %}
                 {% endif %}
+                
             </div>
             {% endif %}
         </div>

--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -84,7 +84,6 @@
                     <div class="alert alert-error">{{ error }}</div>
                     {% endfor %}
                 {% endif %}
-                
             </div>
             {% endif %}
         </div>

--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -45,39 +45,44 @@
                             <label for="emails">{{ _('Email addresses') }}</label>
                         </div>
                         <button type="submit" id="submit">{{ _('Find accounts') }}</button>
-                        <script>
-                            var inputEmails = document.getElementById('emails');
-                            var findAccountButton = document.getElementById('submit');
-                            var originalBackgroundColor = findAccountButton.style.backgroundColor;
-                            function validEmails(val) {
-                                var emails = val.replace(/\s/g,'').split(",");
-                                var valid = true;
-                                var regex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-                                for (var i = 0; i < emails.length; i++) {
-                                    if( emails[i] == "" || ! regex.test(emails[i])){
-                                        valid = false;
-                                    }
-                                }
-                                return valid
-                            }
-                            function checkInput() {
-                                var emailList = inputEmails.value;
-                                if (validEmails(emailList)){
-                                    findAccountButton.disabled = false;
-                                    findAccountButton.style.backgroundColor = originalBackgroundColor;
-                                    findAccountButton.style.cursor = "pointer";
-                                    findAccountButton.style["pointer-events"] = "auto";
-                                } else {
-                                    findAccountButton.disabled = true;
-                                    findAccountButton.style.backgroundColor = 'grey';
-                                    findAccountButton.style.cursor = "not-allowed";
-                                    findAccountButton.style["pointer-events"] = "none";
-                                }
-                            }
-                        </script>
+                        
                     </div>
                     <div><i>{{ form.emails.help_text }}</i></div>
                 </form>
+                <div id="errors_realtime", name="errors_realtime"></div>
+                <script>
+                    var inputEmails = document.getElementById('emails');
+                    var findAccountButton = document.getElementById('submit');
+                    var warningMessage = document.getElementById('errors_realtime');
+                    var originalBackgroundColor = findAccountButton.style.backgroundColor;
+                    function validEmails(val) {
+                        var emails = val.replace(/\s/g,'').split(",");
+                        var valid = true;
+                        var regex = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+                        for (var i = 0; i < emails.length; i++) {
+                            if( emails[i] == "" || ! regex.test(emails[i])){
+                                valid = false;
+                            }
+                        }
+                        return valid
+                    }
+                    function checkInput() {
+                        var emailList = inputEmails.value;
+                        if (validEmails(emailList)){
+                            findAccountButton.disabled = false;
+                            findAccountButton.style.backgroundColor = originalBackgroundColor;
+                            findAccountButton.style.cursor = "pointer";
+                            findAccountButton.style["pointer-events"] = "auto";
+                            warningMessage.innerHTML = ""
+                        } else {
+                            findAccountButton.disabled = true;
+                            findAccountButton.style.backgroundColor = 'grey';
+                            findAccountButton.style.cursor = "not-allowed";
+                            findAccountButton.style["pointer-events"] = "none";
+                            warningMessage.innerHTML = "<div class='alert alert-error'>Enter a valid email address</div>"
+                        }
+                    }
+                </script>
                 <div id="errors"></div>
                 {% if form.emails.errors %}
                     {% for error in form.emails.errors %}

--- a/templates/zerver/find_account.html
+++ b/templates/zerver/find_account.html
@@ -44,7 +44,7 @@
                             <input type="text" autofocus id="emails" name="emails" required onKeyUp="checkInput()"/>
                             <label for="emails">{{ _('Email addresses') }}</label>
                         </div>
-                        <button type="submit" id="submit">{{ _('Find accounts') }}</button>
+                        <button type="submit" id="submit_button">{{ _('Find accounts') }}</button>
                         
                     </div>
                     <div><i>{{ form.emails.help_text }}</i></div>
@@ -52,7 +52,7 @@
                 <div id="errors_realtime", name="errors_realtime"></div>
                 <script>
                     var inputEmails = document.getElementById('emails');
-                    var findAccountButton = document.getElementById('submit');
+                    var findAccountButton = document.getElementById('submit_button');
                     var warningMessage = document.getElementById('errors_realtime');
                     var originalBackgroundColor = findAccountButton.style.backgroundColor;
                     function validEmails(val) {

--- a/zerver/tests/test_signup.py
+++ b/zerver/tests/test_signup.py
@@ -5945,9 +5945,6 @@ class TestFindMyTeam(ZulipTestCase):
             "/accounts/find/", dict(emails="iago@zulip.com,cordeliA@zulip.com")
         )
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(
-            result["Location"], "/accounts/find/?emails=iago%40zulip.com%2CcordeliA%40zulip.com"
-        )
         result = self.client_get(result["Location"])
         content = result.content.decode()
         self.assertIn("Emails sent! You will only receive emails", content)
@@ -5968,10 +5965,6 @@ class TestFindMyTeam(ZulipTestCase):
             "/accounts/find/", dict(emails="iago@zulip.com,invalid_email@zulip.com")
         )
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(
-            result["Location"],
-            "/accounts/find/?emails=iago%40zulip.com%2Cinvalid_email%40zulip.com",
-        )
         result = self.client_get(result["Location"])
         content = result.content.decode()
         self.assertIn("Emails sent! You will only receive emails", content)
@@ -6006,7 +5999,6 @@ class TestFindMyTeam(ZulipTestCase):
         data = {"emails": self.example_email("hamlet")}
         result = self.client_post("/accounts/find/", data)
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "/accounts/find/?emails=hamlet%40zulip.com")
         from django.core.mail import outbox
 
         self.assert_length(outbox, 1)
@@ -6016,7 +6008,6 @@ class TestFindMyTeam(ZulipTestCase):
         data = {"emails": self.example_email("hamlet")}
         result = self.client_post("/accounts/find/", data)
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "/accounts/find/?emails=hamlet%40zulip.com")
         from django.core.mail import outbox
 
         self.assert_length(outbox, 0)
@@ -6026,7 +6017,6 @@ class TestFindMyTeam(ZulipTestCase):
         data = {"emails": self.example_email("hamlet")}
         result = self.client_post("/accounts/find/", data)
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "/accounts/find/?emails=hamlet%40zulip.com")
         from django.core.mail import outbox
 
         self.assert_length(outbox, 0)
@@ -6035,7 +6025,6 @@ class TestFindMyTeam(ZulipTestCase):
         data = {"emails": self.example_email("webhook_bot")}
         result = self.client_post("/accounts/find/", data)
         self.assertEqual(result.status_code, 302)
-        self.assertEqual(result["Location"], "/accounts/find/?emails=webhook-bot%40zulip.com")
         from django.core.mail import outbox
 
         self.assert_length(outbox, 0)

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -826,9 +826,6 @@ def find_account(
                     request=request,
                 )
 
-            # Note: Show all the emails in the result otherwise this
-            # feature can be used to ascertain which email addresses
-            # are associated with Zulip.
     else:
         form = FindMyTeamForm()
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -763,8 +763,6 @@ def accounts_home_from_multiuse_invite(request: HttpRequest, confirmation_key: s
         request, multiuse_object_key=confirmation_key, multiuse_object=multiuse_object
     )
 
-    
-
 
 @has_request_variables
 def find_account(

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -1,5 +1,4 @@
 import logging
-import urllib
 from typing import Any, Dict, Iterable, List, Optional
 from urllib.parse import urlencode
 

--- a/zerver/views/registration.py
+++ b/zerver/views/registration.py
@@ -764,6 +764,8 @@ def accounts_home_from_multiuse_invite(request: HttpRequest, confirmation_key: s
         request, multiuse_object_key=confirmation_key, multiuse_object=multiuse_object
     )
 
+    
+
 
 @has_request_variables
 def find_account(
@@ -827,20 +829,8 @@ def find_account(
             # Note: Show all the emails in the result otherwise this
             # feature can be used to ascertain which email addresses
             # are associated with Zulip.
-            data = urllib.parse.urlencode({"emails": ",".join(emails)})
-            return redirect(append_url_query_string(url, data))
     else:
         form = FindMyTeamForm()
-        # The below validation is perhaps unnecessary, in that we
-        # shouldn't get able to get here with an invalid email unless
-        # the user hand-edits the URLs.
-        if raw_emails:
-            for email in raw_emails.split(","):
-                try:
-                    validators.validate_email(email)
-                    emails.append(email)
-                except ValidationError:
-                    pass
 
     return render(
         request,


### PR DESCRIPTION
<!-- Describe your pull request here.-->

Partially Fixes: #3128

- [x] You shouldn't be able to click "Find team" if you don't have a valid list of email addresses. Slack does this really nicely: [slack.com/signin/find](https://slack.com/signin/find)

- [ ] We should send an email regardless of whether they are in a Zulip org or not.

- [ ] The followup page should have links to resend the email or enter a different email address.

- [x] The URL of the followup page currently has the email as a URL parameter, which should be removed.

We chose to complete subtasks 1 & 4. We believe that subtask 2 is a design choice and should be carefully discussed with other developers. We believe that subtask 3 is not necessary if we valid the emails in subtask 1.

**Screenshots and screen captures:**

If the user enters an invalid list of emails, the warning message will show up automatically without clicking the `Find accounts` button. Also, the submit button will become grey and unclickable.
<img width="638" alt="image" src="https://user-images.githubusercontent.com/21675671/206793860-c5801b31-84f5-416e-abf9-3bd774572894.png">

Otherwise, the `Find accounts` button is clickable.
<img width="652" alt="image" src="https://user-images.githubusercontent.com/21675671/206800148-4b466770-07a2-4e2d-b30e-2e1556573cf1.png">

After we click `Find accounts` with the email address `user-24@zulip.com`. We enter the follow-up page. The emails in the URL are removed as expected.
![Screen Shot 2022-12-09 at 4 29 21 PM](https://user-images.githubusercontent.com/21675671/206799296-40af9c26-dcac-44dd-839c-a681548ad034.jpeg)


